### PR TITLE
mpd_get_title: call basename only when using path

### DIFF
--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -266,8 +266,9 @@ char* mpd_get_title(struct mpd_song const *song)
     char *str, *ptr;
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_TITLE, 0);
-    if(str == NULL)
-        str = (char *)mpd_song_get_uri(song);
+    if(str == NULL){
+        str = basename((char *)mpd_song_get_uri(song));
+    }
 
     if(str == NULL)
         return NULL;
@@ -277,7 +278,7 @@ char* mpd_get_title(struct mpd_song const *song)
         if(*ptr=='"')
             *ptr='\'';
 
-    return basename(str);
+    return str;
 }
 
 int mpd_put_state(char *buffer, int *current_song_id, unsigned *queue_version)


### PR DESCRIPTION
This fixes a bug where tracks containing slashes in their name we trimmed as if they where paths.

For example, "Morning Bell/Amnesiac" would return "Amnesiac".
