### PR TITLE
Allow the sytemd unit to read a configuration file

### DIFF
--- a/contrib/ympd.service
+++ b/contrib/ympd.service
@@ -3,7 +3,11 @@ Description=ympd server daemon
 Requires=network.target local-fs.target
 
 [Service]
-ExecStart=/usr/bin/ympd
+Environment=MPD_HOST=localhost
+Environment=MPD_PORT=6600
+Environment=WEB_PORT=8080
+EnvironmentFile=/etc/conf.d/ympd
+ExecStart=/usr/bin/ympd -h $MPD_HOST -p $MPD_PORT  -w $WEB_PORT
 Type=simple
 
 [Install]


### PR DESCRIPTION
Already having a service using the port 8080, I had to change it on ympd. The only way currently was to edit the systemd unit by hand, to add the `-w` option. This pull request add the ability to create a configuration file in `/etc/conf.d/ympd` instead, to set three variables (`MPD_HOST`, `MPD_PORT` and `WEB_PORT`, matching the `-h`, `-p` and `-w` options). Default values are hard-coded in the systemd unit file as I don't know any way to set them conditionally.
