### PR TITLE
make service environment file optional

### DIFF
--- a/contrib/ympd.service
+++ b/contrib/ympd.service
@@ -6,7 +6,7 @@ Requires=network.target local-fs.target
 Environment=MPD_HOST=localhost
 Environment=MPD_PORT=6600
 Environment=WEB_PORT=8080
-EnvironmentFile=/etc/conf.d/ympd
+EnvironmentFile=-/etc/conf.d/ympd
 ExecStart=/usr/bin/ympd -h $MPD_HOST -p $MPD_PORT  -w $WEB_PORT
 Type=simple
 


### PR DESCRIPTION
Currently, the systemd service fails to start if /etc/conf.d/ympd doesn't exist.

According to the [systemd doc](http://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=),  prefixing the filename with a `-` makes it optional so the service can start with the default value when there is no config file.
