### PR TITLE
remove webkit prefix from notifications

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -502,7 +502,7 @@ $('#btnnotify').on('click', function (e) {
             }
 
             if (permission === "granted") {
-                $.cookie("notification", true);
+                $.cookie("notification", true, { expires: 424242 });
                 $('btnnotify').addClass("active");
             }
         });


### PR DESCRIPTION
You asked for a pull request?
This was shortly tested with the newest stable firefox and chromium versions on (arch) linux and I assume it works.
And just for the record: I really dislike webdevelopement, javascript and jquery.
