### PR TITLE
First attempt at Windows port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ set(SOURCES
 
 add_executable(ympd ${SOURCES})
 target_link_libraries(ympd ${LIBMPDCLIENT_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+if (WIN32)
+    target_link_libraries(ympd ws2_32)
+endif()
 
 install(TARGETS ympd DESTINATION bin)
 install(FILES ympd.1 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1)

--- a/htdocs/mkdata.c
+++ b/htdocs/mkdata.c
@@ -58,16 +58,20 @@ int main(int argc, char *argv[])
     int i, j, buf;
     FILE *fd;
 
-    if(argc <= 1)
-        error(EXIT_FAILURE, 0, "Usage: ./%s <this_file> <file1> [file2, ...] > embedded_data.c", argv[0]);
+    if(argc <= 1) {
+        printf("Usage: ./%s <this_file> <file1> [file2, ...] > embedded_data.c", argv[0]);
+        return 0;
+    }
 
     for(i = 1; i < argc; i++)
     {
         printf("static const unsigned char v%d[] = {", i);
         
-        fd = fopen(argv[i], "r");
-        if(!fd)
-            error(EXIT_FAILURE, errno, "Failed open file %s", argv[i]);
+        fd = fopen(argv[i], "rb");
+        if(!fd) {
+            fprintf(stderr, "Failed to open file %s: %s", argv[i], strerror(errno));
+            return errno;
+        }
 
         j = 0;
         while((buf = fgetc(fd)) != EOF)


### PR DESCRIPTION
CMakeLists.txt:
- Added a conditional to link WinSock on Windows - Mongoose doesn't
  compile otherwise

mkdata.c:
- Changed error handling to use standard C routines - no error() on
  Windows
- Changed file mode to "rb" - avoids early EOFs on null bytes on Windows

What doesn't work:
- DB browsing
- Search?

What works:
- Everything else

All tested with Fedora 20, both native compilation and MinGW(-w64), MinGW cross-compiled binaries of mpd, libmpdclient (both from git) and ympd also tested on Windows 8.1 64-bit. Any ideas as to what breaks search/DB? I don't really have any established debugging workflow on Windows, so it'll take me some time to figure out how to figure it out. 
