### PR TITLE
ympd.c: add a break statement for the mpd port argument

### DIFF
--- a/src/ympd.c
+++ b/src/ympd.c
@@ -98,6 +98,7 @@ int main(int argc, char **argv)
                 break;
             case 'p':
                 mpd.port = atoi(optarg);
+                break;
             case 'w':
                 error_msg = mg_set_option(server, "listening_port", optarg);
                 break;


### PR DESCRIPTION
Otherwise, passing -p tried to also bind the http server to MPD's port
(which was already in use by MPD...)
