### PR TITLE
add break inside the -p args switch statement

### DIFF
--- a/src/ympd.c
+++ b/src/ympd.c
@@ -81,6 +81,7 @@ int main(int argc, char **argv)
                 break;
             case 'p':
                 mpd.port = atoi(optarg);
+                break;
             case 'w':
                 mg_set_option(server, "listening_port", optarg);
                 break;


### PR DESCRIPTION
Not sure why it dind't cause any probelems before, but after building with the latest version I couldn't use the -p argument anymore. ympd always exited with the following error:

`Mongoose error: Cannot bind to port`

Turns out there was no break in the switch case for that argument. Adding the break solved the problem.
