### PR TITLE
Change websocket URL to allow easy incorporation of different backends.

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -419,9 +419,9 @@ function get_appropriate_ws_url()
             u = u.substr(7);
     }
 
-    u = u.split('/');
+    u = u.split('#');
 
-    return pcol + u[0];
+    return pcol + u[0] + "/ws";
 }
 
 var updateVolumeIcon = function(volume)


### PR DESCRIPTION
I propose a slight change to the javascript function which creates the websocket URL.

This way the websocket connects on an URL different from the webpage. This makes it easier to use a different backend, for example the Python backend I created (https://github.com/iwanders/ympd_python).

The original C backend does not require any changes to continue working.