### PR TITLE
various patches: manpage, remove external js, init scripts

### DIFF
--- a/contrib/init.debian
+++ b/contrib/init.debian
@@ -1,8 +1,8 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          ympd
-# Required-Start:    $local_fs $mpd
-# Required-Stop:     $local_fs $mpd
+# Required-Start:    $remote_fs mpd
+# Required-Stop:     $remote_fs mpd
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Daemonized version of ympd.
@@ -20,8 +20,11 @@ PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 LOG_OUT=/var/log/$NAME.out
 LOG_ERR=/var/log/$NAME.err
-YMPD_USER=mpd
-DAEMON_OPT="--user $YMPD_USER --webport 8080"
+YMPD_USER=nobody
+MPD_HOST=localhost
+MPD_PORT=6600
+WEB_PORT=8080
+
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
@@ -31,6 +34,8 @@ DAEMON_OPT="--user $YMPD_USER --webport 8080"
 
 # Load the VERBOSE setting and other rcS variables
 [ -f /etc/default/rcS ] && . /etc/default/rcS
+
+DAEMON_OPT="--user $YMPD_USER --webport $MPD_WEBHOST --host $MPD_HOST --port $MPD_PORT"
 
 do_start()
 {

--- a/contrib/ympd.default
+++ b/contrib/ympd.default
@@ -1,0 +1,4 @@
+MPD_HOST=localhost
+MPD_PORT=6600
+WEB_PORT=8080
+YMPD_USER=nobody

--- a/contrib/ympd.service
+++ b/contrib/ympd.service
@@ -6,8 +6,9 @@ Requires=network.target local-fs.target
 Environment=MPD_HOST=localhost
 Environment=MPD_PORT=6600
 Environment=WEB_PORT=8080
-EnvironmentFile=-/etc/conf.d/ympd
-ExecStart=/usr/bin/ympd -h $MPD_HOST -p $MPD_PORT  -w $WEB_PORT
+Environment=YMPD_USER=nobody
+EnvironmentFile=/etc/default/ympd
+ExecStart=/usr/bin/ympd --user $YMPD_USER --webport $MPD_WEBHOST --host $MPD_HOST --port $MPD_PORT
 Type=simple
 
 [Install]

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -16,12 +16,6 @@
   <!-- Custom styles for this template -->
   <link href="css/mpd.min.css" rel="stylesheet">
   <link href="assets/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon">
-
-  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-  <!--[if lt IE 9]>
-  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
-  <![endif]-->
 </head>
 <body>
 

--- a/ympd.1
+++ b/ympd.1
@@ -1,6 +1,6 @@
 .\" Manpage for ympd.
 .\" Contact andy@ympd.org to correct errors or typos.
-.TH man 8 "18 Mar 2014" "1.2" "ympd man page"
+.TH man 1 "19 Oct 2014" "1.2.3" "ympd man page"
 .SH NAME
 ympd \- Standalone MPD Web GUI written in C, utilizing Websockets and Bootstrap/JS
 .SH SYNOPSIS


### PR DESCRIPTION
Hi !

As discussed by email.  I split each patch in a separate commit.

I was also wondering if it would make sense to install the init script, systemd unit file as well as the new ympd.default file I've added, with cmake.

Basically: If we can detect systemd is installed, install the .service, if not, install the init script. Always install the default config file (ympd.default -> /etc/default/ympd)

What do you think ?