### PR TITLE
systemd and init: fix WEB_PORT

### DIFF
--- a/contrib/init.debian
+++ b/contrib/init.debian
@@ -35,7 +35,7 @@ WEB_PORT=8080
 # Load the VERBOSE setting and other rcS variables
 [ -f /etc/default/rcS ] && . /etc/default/rcS
 
-DAEMON_OPT="--user $YMPD_USER --webport $MPD_WEBHOST --host $MPD_HOST --port $MPD_PORT"
+DAEMON_OPT="--user $YMPD_USER --webport $WEB_PORT --host $MPD_HOST --port $MPD_PORT"
 
 do_start()
 {

--- a/contrib/ympd.service
+++ b/contrib/ympd.service
@@ -8,7 +8,7 @@ Environment=MPD_PORT=6600
 Environment=WEB_PORT=8080
 Environment=YMPD_USER=nobody
 EnvironmentFile=/etc/default/ympd
-ExecStart=/usr/bin/ympd --user $YMPD_USER --webport $MPD_WEBHOST --host $MPD_HOST --port $MPD_PORT
+ExecStart=/usr/bin/ympd --user $YMPD_USER --webport $WEB_PORT --host $MPD_HOST --port $MPD_PORT
 Type=simple
 
 [Install]


### PR DESCRIPTION
I think ther was a little mistake in the latest changes to the init script and systemd service.
(I only tested with systemd, but I'm pretty sure they both work.)