### PR TITLE
Improve the add stream dialog user experience.

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -106,6 +106,13 @@ $(document).ready(function(){
         }
     });
 
+    $('#addstream').on('shown.bs.modal', function () {
+        $('#streamurl').focus();
+     })
+    $('#addstream form').on('submit', function (e) {
+        addStream();
+    });
+
     if(!notificationsSupported())
         $('#btnnotify').addClass("disabled");
     else
@@ -573,6 +580,7 @@ function addStream() {
     if($('#streamurl').val().length > 0) {
     	socket.send('MPD_API_ADD_TRACK,'+$('#streamurl').val());
     }
+    $('#streamurl').val("");
     $('#addstream').modal('hide');
 }
 


### PR DESCRIPTION
When the dialog is opened, the text area is focused. When enter is
pressed (and the form is submit) the window now behaves as expected and
adds the stream to the playlist and closes. The text area is now also
cleared once the form is submit, previously the old stream was still
visible when the dialog was opened a second time.