### PR TITLE
Add "Add all" button in the Browse section

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -97,6 +97,11 @@
           <ol id="breadcrump" class="breadcrumb">
           </ol>
 
+          <div class="col-md-12">
+          <button id="add-all-songs" class="btn btn-primary pull-right">Add all</button>
+          </div>
+
+
           <!-- Table -->
           <table id="salamisandwich" class="table table-hover">
             <thead>

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -41,6 +41,7 @@ var app = $.sammy(function() {
     function prepare() {
         $('#nav_links > li').removeClass('active');
         $('.page-btn').addClass('hide');
+        $('#add-all-songs').hide();
         pagination = 0;
         browsepath = '';
     }
@@ -59,6 +60,15 @@ var app = $.sammy(function() {
         $('#breadcrump').removeClass('hide').empty().append("<li><a href=\"#/browse/0/\">root</a></li>");
         $('#salamisandwich').find("tr:gt(0)").remove();
         socket.send('MPD_API_GET_BROWSE,'+pagination+','+(browsepath ? browsepath : "/"));
+        // Don't add all songs from root
+        if (browsepath) {
+            var add_all_songs = $('#add-all-songs');
+            add_all_songs.off(); // remove previous binds
+            add_all_songs.on('click', function() {
+                socket.send('MPD_API_ADD_TRACK,'+browsepath);
+            });
+            add_all_songs.show();
+        }
 
         $('#panel-heading').text("Browse database: "+browsepath);
         var path_array = browsepath.split('/');


### PR DESCRIPTION
It adds all items in the currently browsed directory. It's equivalent to clicking on "+"
on that same directory we decided to browse.

It happens to me quite often that I want to add a whole directory, but I want to look at what it contains first. With my root folder being quite large, it's really cumbersome to go back one level and scroll down to that directory again. Hence, this handy shortcut.