### PR TITLE
Dirble fixes

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -28,6 +28,7 @@ var MAX_ELEMENTS_PER_PAGE = 512;
 var dirble_selected_cat = "";
 var dirble_catid = "";
 var dirble_page = 1;
+var dirble_api_key = "INSERT_DIRBLE_API_KEY_HERE";
 var isTouch = Modernizr.touch ? 1 : 0;
 
 var app = $.sammy(function() {
@@ -784,7 +785,7 @@ function dirble_load_categories() {
 
     dirble_page = 1;
 
-    $.getJSON( "http://api.dirble.com/v2/categories?token=2e223c9909593b94fc6577361a", function( data ) {
+    $.getJSON( "http://api.dirble.com/v2/categories?token="+dirble_api_key, function( data ) {
 
         $('#dirble_loading').addClass('hide');
 
@@ -832,7 +833,7 @@ function dirble_load_categories() {
 
 function dirble_load_stations() {
 
-    $.getJSON( "http://api.dirble.com/v2/category/"+dirble_catid+"/stations?page="+dirble_page+"&per_page=20&token=2e223c9909593b94fc6577361a", function( data ) {
+    $.getJSON( "http://api.dirble.com/v2/category/"+dirble_catid+"/stations?page="+dirble_page+"&per_page=20&token="+dirble_api_key, function( data ) {
 
         $('#dirble_loading').addClass('hide');
         if (data.length == 20) $('#next').removeClass('hide');
@@ -859,7 +860,7 @@ function dirble_load_stations() {
             click: function() {
                 var _this = $(this);
 
-                $.getJSON( "http://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token=2e223c9909593b94fc6577361a", function( data ) {
+                $.getJSON( "http://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                     socket.send("MPD_API_ADD_TRACK," + data.streams[0].stream);
                     $('.top-right').notify({
@@ -877,7 +878,7 @@ function dirble_load_stations() {
                 "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
                     e.stopPropagation();
 
-                    $.getJSON( "http://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token=2e223c9909593b94fc6577361a", function( data ) {
+                    $.getJSON( "http://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                         socket.send("MPD_API_ADD_PLAY_TRACK," + data.streams[0].stream);
                         $('.top-right').notify({
@@ -898,7 +899,7 @@ function dirble_load_stations() {
             click: function() {
                 var _this = $(this);
 
-                $.getJSON( "http://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token=2e223c9909593b94fc6577361a", function( data ) {
+                $.getJSON( "http://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                     socket.send("MPD_API_ADD_TRACK," + data.streams[0].stream);
                     $('.top-right').notify({
@@ -916,7 +917,7 @@ function dirble_load_stations() {
                 "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
                     e.stopPropagation();
 
-                    $.getJSON( "http://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token=2e223c9909593b94fc6577361a", function( data ) {
+                    $.getJSON( "http://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                         socket.send("MPD_API_ADD_PLAY_TRACK," + data.streams[0].stream);
                         $('.top-right').notify({

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -532,12 +532,12 @@ function get_appropriate_ws_url()
     /* https:// url itself, otherwise unencrypted
     /*/
 
-    if (u.substring(0, 5) == "https") {
+    if (location.protocol == "https:") {
         pcol = "wss://";
         u = u.substr(8);
     } else {
         pcol = "ws://";
-        if (u.substring(0, 4) == "http")
+        if (location.protocol == "http:")
             u = u.substr(7);
     }
 
@@ -785,7 +785,7 @@ function dirble_load_categories() {
 
     dirble_page = 1;
 
-    $.getJSON( "http://api.dirble.com/v2/categories?token="+dirble_api_key, function( data ) {
+    $.getJSON( location.protocol+"//api.dirble.com/v2/categories?token="+dirble_api_key, function( data ) {
 
         $('#dirble_loading').addClass('hide');
 
@@ -833,7 +833,7 @@ function dirble_load_categories() {
 
 function dirble_load_stations() {
 
-    $.getJSON( "http://api.dirble.com/v2/category/"+dirble_catid+"/stations?page="+dirble_page+"&per_page=20&token="+dirble_api_key, function( data ) {
+    $.getJSON( location.protocol+"//api.dirble.com/v2/category/"+dirble_catid+"/stations?page="+dirble_page+"&per_page=20&token="+dirble_api_key, function( data ) {
 
         $('#dirble_loading').addClass('hide');
         if (data.length == 20) $('#next').removeClass('hide');
@@ -860,7 +860,7 @@ function dirble_load_stations() {
             click: function() {
                 var _this = $(this);
 
-                $.getJSON( "http://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token="+dirble_api_key, function( data ) {
+                $.getJSON( location.protocol+"//api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                     socket.send("MPD_API_ADD_TRACK," + data.streams[0].stream);
                     $('.top-right').notify({
@@ -878,7 +878,7 @@ function dirble_load_stations() {
                 "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
                     e.stopPropagation();
 
-                    $.getJSON( "http://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token="+dirble_api_key, function( data ) {
+                    $.getJSON( location.protocol+"//api.dirble.com/v2/station/"+_this.attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                         socket.send("MPD_API_ADD_PLAY_TRACK," + data.streams[0].stream);
                         $('.top-right').notify({
@@ -899,7 +899,7 @@ function dirble_load_stations() {
             click: function() {
                 var _this = $(this);
 
-                $.getJSON( "http://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token="+dirble_api_key, function( data ) {
+                $.getJSON( location.protocol+"//api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                     socket.send("MPD_API_ADD_TRACK," + data.streams[0].stream);
                     $('.top-right').notify({
@@ -917,7 +917,7 @@ function dirble_load_stations() {
                 "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
                     e.stopPropagation();
 
-                    $.getJSON( "http://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token="+dirble_api_key, function( data ) {
+                    $.getJSON( location.protocol+"//api.dirble.com/v2/station/"+_this.attr("radioid")+"?token="+dirble_api_key, function( data ) {
 
                         socket.send("MPD_API_ADD_PLAY_TRACK," + data.streams[0].stream);
                         $('.top-right').notify({


### PR DESCRIPTION
Commit f68e1d0 makes it easier to change Dirble token by creating a new variable, `dirble_api_key`, and changing every instance of `"token=2e223c9909593b94fc6577361a"` to `"token="+dirble_api_key`, so you just need to change a variable instead of finding every instance of `token=` in `htdocs/js/mpd.js`. Ideally this should be allowed to be set in command line, by adding a new option like `-d, --dirble-api-key`, instead of making the user to recompile the whole source code just to change the API key, however this already helps a little. Partially fixes issue #115.

Commit 99b8ae0 changes Dirble url according to which protocol ympd is running currently (using property `location.protocol`). If the user is using `https` instead of `http`, Dirble would fail because it would try to access the API via `http`. Note that maybe it would be better to simple force `https` everywhere, however I don't know if this breaks something elsewhere. I changed `get_appropriate_ws_url()` to use `location.protocol` too, since this seems much more robust.
