### PR TITLE
Fix double slashes in websocket URL

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -525,6 +525,7 @@ function get_appropriate_ws_url()
 {
     var pcol;
     var u = document.URL;
+    var separator;
 
     /*
     /* We open the websocket encrypted if this page came on an
@@ -542,7 +543,13 @@ function get_appropriate_ws_url()
 
     u = u.split('#');
 
-    return pcol + u[0] + "/ws";
+    if (/\/$/.test(u[0])) {
+        separator = "";
+    } else {
+        separator = "/";
+    }
+
+    return pcol + u[0] + separator + "ws";
 }
 
 var updateVolumeIcon = function(volume)


### PR DESCRIPTION
Some proxies (like Træfik) send a 301 redirect when requesting `ws://hostname.fqdn//ws`, redirecting to `ws://hostname.fqdn/ws`. For a weird reason (I don't know the real explanation behind that behavior), Firefox (at least) fails to follow the 301 redirect to the web-socket endpoint. So here's a little patch which avoid putting a double `/` in the web-socket endpoint URL.
