### PR TITLE
added FreeBSD RC script

### DIFF
--- a/contrib/ympd.freebsd
+++ b/contrib/ympd.freebsd
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# PROVIDE: ympd
+# REQUIRE: DAEMON musicpd
+# KEYWORD: shutdown
+
+# Add the following line to /etc/rc.conf to enable ympd:
+#
+# ympd_enable="YES"
+
+. /etc/rc.subr
+
+name="ympd"
+rcvar="${name}_enable"
+command="/usr/local/bin/ympd"
+pidfile="/var/run/${name}.pid"
+start_cmd="ympd_start"
+
+load_rc_config "$name"
+: ${ympd_enable:="NO"}
+: ${ympd_user:="nobody"}
+
+ympd_start()
+{
+	check_startmsgs && echo "Starting ${name}."
+	/usr/sbin/daemon -f -p "${pidfile}" -t "${name}" -u "${ympd_user}" "${command}"
+}
+
+run_rc_command "$1"


### PR DESCRIPTION
Copy contrib/ympd.freebsd to /usr/local/etc/rc.d/ympd and add ympd_enable="YES" to /etc/rc.conf in order to start ympd during system boot.
Tested on FreeBSD 11.0. Should run on any FreeBSD version >= 9.0