### PR TITLE
Don't overwrite CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ include_directories(${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}	${LIBMPDCLIENT_I
 
 include(CheckCSourceCompiles)
 
-set(CMAKE_C_FLAGS "-std=gnu99 -Wall")
-set(CMAKE_C_FLAGS_DEBUG "-ggdb -pedantic")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -Wall")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -ggdb -pedantic")
 if(WITH_IPV6)
     set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS NS_ENABLE_IPV6)
 endif()


### PR DESCRIPTION
Preserve user/system-configured C_FLAGS.

This broke the rpm package build on fedora: They enable a hardened config (i.e. ASLR) by default, which adds -pie and -fPIC to linker and compiler flags. Overwriting C_FLAGS removed the compiler spec, but not the linker one, leading to an error like:

/bin/cc  -std=gnu99 -Wall -ggdb -pedantic  -specs=/usr/lib/rpm/redhat/redhat-hardened-ld CMakeFiles/mkdata.dir/tools/mkdata.c.o  -o mkdata -rdynamic 
bin/ld: CMakeFiles/mkdata.dir/tools/mkdata.c.o: relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
CMakeFiles/mkdata.dir/tools/mkdata.c.o: error adding symbols: Bad value

With this fix, the error is gone:

/bin/cc  -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -std=gnu99 -Wall -g -ggdb -pedantic  -specs=/usr/lib/rpm/redhat/redhat-hardened-ld CMakeFiles/mkdata.dir/tools/mkdata.c.o  -o mkdata -rdynamic