### PR TITLE
Update FreeBSD RC script

### DIFF
--- a/contrib/ympd.freebsd
+++ b/contrib/ympd.freebsd
@@ -12,18 +12,17 @@
 
 name="ympd"
 rcvar="${name}_enable"
-command="/usr/local/bin/ympd"
+command="/usr/local/bin/${name}"
 pidfile="/var/run/${name}.pid"
 start_cmd="ympd_start"
 
-load_rc_config "$name"
+load_rc_config "${name}"
 : ${ympd_enable:="NO"}
-: ${ympd_user:="nobody"}
 
 ympd_start()
 {
 	check_startmsgs && echo "Starting ${name}."
-	/usr/sbin/daemon -f -p "${pidfile}" -t "${name}" -u "${ympd_user}" "${command}"
+	/usr/sbin/daemon -f -p "${pidfile}" "${command}" "${rc_flags}"
 }
 
 run_rc_command "$1"


### PR DESCRIPTION
- removed /usr/sbin/daemon's option "-t" (it first appeared in FreeBSD 11, leading to an error in previous versions; since the [t]itle defaults to the daemonized invocation anyways, this shouldn't make a difference for FreeBSD 11+)
- removed /usr/sbin/daemon's option "-u" and the respective variable, since ympd has to be started as root to be able to bind to port 80
- allow for additional arguments via ympd_flags="" in rc.conf