### PR TITLE
Added queue's total time & case insensitive sorting; ignore empty search string

### DIFF
--- a/htdocs/css/mpd.css
+++ b/htdocs/css/mpd.css
@@ -55,11 +55,11 @@ body {
   }
 }
 
-#salamisandwich td:nth-last-child(2), th:nth-last-child(2) {
+td:nth-last-child(2), th:nth-last-child(2) {
   text-align: right;
 }
 
-#salamisandwich td:nth-child(2) span {
+td:nth-child(2) span {
   font-style: italic;
   font-size: 90%;
 
@@ -70,7 +70,8 @@ tbody {
   cursor: pointer;
 }
 
-td:last-child, td:first-child {
+td:last-child, td:first-child,
+th:last-child, th:first-child {
   width: 30px;
 }
 
@@ -97,7 +98,7 @@ button {
 }
 
 #trashmode span:last-child {
-  display:inline-block;
-  text-align:left;
-  width:2.8em;
+  display: inline-block;
+  text-align: left;
+  width: 2.8em;
 }

--- a/htdocs/css/mpd.css
+++ b/htdocs/css/mpd.css
@@ -55,7 +55,7 @@ body {
   }
 }
 
-td:nth-last-child(2), th:nth-last-child(2) {
+#salamisandwich td:nth-last-child(2), th:nth-last-child(2) {
   text-align: right;
 }
 

--- a/htdocs/css/mpd.css
+++ b/htdocs/css/mpd.css
@@ -60,8 +60,10 @@ body {
 }
 
 #salamisandwich td:nth-child(2) span {
-  font-style:italic;
-  font-size:90%;
+  font-style: italic;
+  font-size: 90%;
+
+  display: block;
 }
 
 tbody {

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -81,10 +81,11 @@
 
       <div class="col-md-10 col-xs-12">
         <div class="notifications top-right"></div>
-        
+
         <div class="panel panel-primary">
           <!-- Default panel contents -->
-          <div class="panel-heading"><b id="panel-heading">Queue</b></div>
+          <div class="panel-heading"><b id="panel-heading">Queue</b>
+                                     <b id="panel-heading-info" class="text pull-right"></b></div>
           <div class="panel-body">
             <h1>
               <span id="track-icon" onclick="clickPlay();" class="glyphicon glyphicon-play"></span>
@@ -218,7 +219,7 @@
           <h5>ympd uses following excellent software:</h5>
           <h6><a href="http://cesanta.com/docs.html">Mongoose</a> <small>GPLv2</small></h6>
           <h6><a href="http://www.musicpd.org/libs/libmpdclient/">libMPDClient</a> <small>BSD License</small></h6>
-	  <hr />
+          <hr />
           <div class="row">
             <div class="form-group col-md-6">
               <button type="button" class="btn btn-default btn-block" onclick="updateDB();">
@@ -296,7 +297,7 @@
       </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
   </div><!-- /.modal -->
-  
+
   <div class="modal fade" id="savequeue" tabindex="-1" role="dialog" aria-labelledby="savequeueLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -308,9 +308,9 @@
         <div class="modal-body">
           <form role="form">
             <div class="row">
-              <div class="form-group col-md-9">
-                <label class="control-label" for="playlistname">Playlist Name</label>
-                <input type="text" class="form-control" id="playlistname" />
+              <div class="form-group col-md-12">
+                <label class="control-label" for="queuename">Playlist Name</label>
+                <input type="text" class="form-control" id="queuename" />
               </div>
             </div>
           </form>

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -86,6 +86,7 @@ var app = $.sammy(function() {
         }
 
         $('#panel-heading').text("Browse Database" + (browsepath ? ': ' : '') + browsepath);
+        $('#panel-heading-info').empty();$
 
         var path_array = browsepath.split('/');
         var full_path = "";
@@ -114,7 +115,9 @@ var app = $.sammy(function() {
             $('#dirble_panel').addClass('hide');
 
             socket.send('MPD_API_SEARCH,' + search_str);
+
             $('#panel-heading').text("Search: " + search_str);
+            $('#panel-heading-info').empty();$
         } else if (current_app == null) {
             app.setLocation('/');
         }

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -1,14 +1,14 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: https://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along
@@ -82,7 +82,7 @@ var app = $.sammy(function() {
             add_all_songs.show();
         }
 
-        $('#panel-heading').text("Browse database: "+browsepath);
+        $('#panel-heading').text("Browse Database: "+browsepath);
         var path_array = browsepath.split('/');
         var full_path = "";
         $.each(path_array, function(index, chunk) {
@@ -289,7 +289,7 @@ function webSocketConnect() {
                       });
                       return $helper;
                     };
-                    
+
                     //Make queue table sortable
                     $('#salamisandwich > tbody').sortable({
                       helper: fixHelperModified,
@@ -352,7 +352,7 @@ function webSocketConnect() {
                                     var details = "<td>" + obj.data[item].artist + "<br /><span>" + obj.data[item].album + "</span></td><td>" + obj.data[item].title + "</td>";
                                 }
 
-				$('#salamisandwich > tbody').append(
+                                $('#salamisandwich > tbody').append(
                                     "<tr uri=\"" + encodeURI(obj.data[item].uri) + "\" class=\"song\">" +
                                     "<td><span class=\"glyphicon glyphicon-music\"></span></td>" + details +
                                     "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
@@ -494,13 +494,13 @@ function webSocketConnect() {
                 case 'outputnames':
                     $('#btn-outputs-block button').remove();
                     if (obj.data.length > 1) {
-		        $.each(obj.data, function(id, name){
+                            $.each(obj.data, function(id, name){
                             var btn = $('<button id="btnoutput'+id+'" class="btn btn-default" onclick="toggleoutput(this, '+id+')"><span class="glyphicon glyphicon-volume-up"></span> '+name+'</button>');
                             btn.appendTo($('#btn-outputs-block'));
                         });
-		    } else {
+                    } else {
                         $('#btn-outputs-block').addClass('hide');
-		    }
+                    }
                     /* remove cache, since the buttons have been recreated */
                     last_outputs = '';
                     break;
@@ -532,7 +532,7 @@ function webSocketConnect() {
                     $('#album').text("");
                     $('#artist').text("");
 
-					$('#btnlove').removeClass("active");
+                    $('#btnlove').removeClass("active");
 
                     $('#currenttrack').text(" " + obj.data.title);
                     var notification = "<strong><h4>" + obj.data.title + "</h4></strong>";
@@ -553,7 +553,7 @@ function webSocketConnect() {
                             message:{html: notification},
                             type: "info",
                         }).show();
-                        
+
                     break;
                 case 'mpdhost':
                     $('#mpdhost').val(obj.data.host);
@@ -563,16 +563,16 @@ function webSocketConnect() {
                     break;
                 case 'dirbleapitoken':
                     dirble_api_token = obj.data;
-                    
-		    if (dirble_api_token) {
-		        $('#dirble').removeClass('hide');
+
+                    if (dirble_api_token) {
+                        $('#dirble').removeClass('hide');
 
                         if (dirble_stations) { dirble_load_stations();   }
                         else {                 dirble_load_categories(); }
 
                     } else {
                         $('#dirble').addClass('hide');
-		    }
+                    }
                     break;
                 case 'error':
                     $('.top-right').notify({
@@ -608,9 +608,9 @@ function get_appropriate_ws_url()
     var separator;
 
     /*
-    /* We open the websocket encrypted if this page came on an
-    /* https:// url itself, otherwise unencrypted
-    /*/
+     * We open the websocket encrypted if this page came
+     * on a https:// url itself, otherwise unencrypted
+     */
 
     if (u.substring(0, 5) == "https") {
         pcol = "wss://";
@@ -710,10 +710,10 @@ function basename(path) {
 
 function clickLove() {
     socket.send("MPD_API_SEND_MESSAGE,mpdas," + ($('#btnlove').hasClass('active') ? "unlove" : "love"));
-	if ( $('#btnlove').hasClass('active') )
-		$('#btnlove').removeClass("active");
-	else
-		$('#btnlove').addClass("active");
+        if ( $('#btnlove').hasClass('active') )
+            $('#btnlove').removeClass("active");
+        else
+            $('#btnlove').addClass("active");
 }
 
 $('#btnrandom').on('click', function (e) {
@@ -858,7 +858,8 @@ function notificationsSupported() {
 }
 
 function songNotify(title, artist, album) {
-    /*var opt = {
+/*
+    var opt = {
         type: "list",
         title: title,
         message: title,

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -241,7 +241,7 @@ function webSocketConnect() {
 
                         $('#salamisandwich > tbody').append(
                             "<tr trackid=\"" + obj.data[song].id + "\"><td>" + (obj.data[song].pos + 1) + "</td>" +
-                                "<td>" + obj.data[song].artist + "<br /><span>" + obj.data[song].album  + "</span></td>" +
+                                "<td>" + obj.data[song].artist + "<span>" + obj.data[song].album  + "</span></td>" +
                                 "<td>" + obj.data[song].title  + "</td>" +
                                 "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
                         "</td><td></td></tr>");
@@ -361,7 +361,7 @@ function webSocketConnect() {
                                 if (typeof obj.data[item].artist === 'undefined') {
                                     var details = "<td colspan=\"2\">" + obj.data[item].title + "</td>";
                                 } else {
-                                    var details = "<td>" + obj.data[item].artist + "<br /><span>" + obj.data[item].album + "</span></td><td>" + obj.data[item].title + "</td>";
+                                    var details = "<td>" + obj.data[item].artist + "<span>" + obj.data[item].album + "</span></td><td>" + obj.data[item].title + "</td>";
                                 }
 
 				$('#salamisandwich > tbody').append(

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -241,8 +241,8 @@ function webSocketConnect() {
 
                         $('#salamisandwich > tbody').append(
                             "<tr trackid=\"" + obj.data[song].id + "\"><td>" + (obj.data[song].pos + 1) + "</td>" +
-                                "<td>" + obj.data[song].artist + "<span>" + obj.data[song].album  + "</span></td>" +
-                                "<td>" + obj.data[song].title  + "</td>" +
+                                "<td>" + obj.data[song].artist + "<span>" + obj.data[song].album + "</span></td>" +
+                                "<td>" + obj.data[song].title + "</td>" +
                                 "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
                         "</td><td></td></tr>");
                     }
@@ -358,15 +358,17 @@ function webSocketConnect() {
                                 var minutes = Math.floor(obj.data[item].duration / 60);
                                 var seconds = obj.data[item].duration - minutes * 60;
 
-                                if (typeof obj.data[item].artist === 'undefined') {
-                                    var details = "<td colspan=\"2\">" + obj.data[item].title + "</td>";
-                                } else {
-                                    var details = "<td>" + obj.data[item].artist + "<span>" + obj.data[item].album + "</span></td><td>" + obj.data[item].title + "</td>";
-                                }
+//                                if (typeof obj.data[item].artist === 'undefined') {
+//                                    var details = "<td colspan=\"2\">" + obj.data[item].title + "</td>";
+//                                } else {
+//                                    var details = "<td>" + obj.data[item].artist + "<span>" + obj.data[item].album + "</span></td><td>" + obj.data[item].title + "</td>";
+//                                }
 
-				$('#salamisandwich > tbody').append(
+                                $('#salamisandwich > tbody').append(
                                     "<tr uri=\"" + encodeURI(obj.data[item].uri) + "\" class=\"song\">" +
-                                    "<td><span class=\"glyphicon glyphicon-music\"></span></td>" + details +
+                                    "<td><span class=\"glyphicon glyphicon-music\"></span></td>" +
+                                    "<td>" + obj.data[song].artist + "<span>" + obj.data[song].album + "</span></td>" +
+                                    "<td>" + obj.data[song].title + "</td>" +
                                     "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
                                     "</td><td></td></tr>"
                                 );

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -222,6 +222,18 @@ function webSocketConnect() {
                     if(current_app !== 'queue')
                         break;
 
+                    if (obj.totalTime > 0) {
+                        var hours = Math.floor(obj.totalTime / 3600);
+                        var minutes = Math.floor(obj.totalTime / 60) - hours * 60;
+                        var seconds = obj.totalTime - hours * 3600 - minutes * 60;
+
+                        $('#panel-heading-info').text('Total: ' +
+                            (hours > 0 ? hours + '\u2009h ' + (minutes < 10 ? '0' : '') : '') +
+                            minutes + '\u2009m ' + (seconds < 10 ? '0' : '') + seconds + '\u2009s');
+                    } else {
+                        $('#panel-heading-info').empty();
+                    }
+
                     $('#salamisandwich > tbody').empty();
                     for (var song in obj.data) {
                         var minutes = Math.floor(obj.data[song].duration / 60);

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -311,7 +311,9 @@ function webSocketConnect() {
                         $('#salamisandwich > tbody').sortable('destroy');
                     }
 
-                    var obj_data = obj.data.map((x,i) => [x.srt,i]).sort();
+                    var obj_data = obj.data.map((x,i) => [x.srt,i]);
+                    /* Only sort if there's a non-empty string to sort after. */
+                    if (obj_data[0][0] !== '') { obj_data = obj_data.sort(); }
 
                     for (var i = 0; i < obj_data.length; i++) {
                         var item = obj_data[i][1];

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -100,13 +100,16 @@ var app = $.sammy(function() {
     });
 
     this.get(/\#\/search\/(.*)/, function() {
-        current_app = 'search';
-        $('#salamisandwich').find("tr:gt(0)").remove();
-        $('#dirble_panel').addClass('hide');
         var search_str = this.params['splat'][0];
 
-        $('#search > div > input').val(search_str);
         if (search_str !== "") {
+            current_app = 'search';
+
+            $('#search > div > input').val(search_str);
+
+            $('#salamisandwich').find("tr:gt(0)").remove();
+            $('#dirble_panel').addClass('hide');
+
             socket.send('MPD_API_SEARCH,' + search_str);
             $('#panel-heading').text("Search: " + search_str);
         }
@@ -785,9 +788,10 @@ function getHost() {
 
 $('#search').submit(function () {
     var search_str = $('#search > div > input').val();
-    app.setLocation("#/search/" + search_str);
 
     if (search_str !== "") {
+        app.setLocation("#/search/" + search_str);
+
         $('#wait').modal('show');
         setTimeout(function() {
             $('#wait').modal('hide');

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -364,17 +364,17 @@ function webSocketConnect() {
                                 var minutes = Math.floor(obj.data[item].duration / 60);
                                 var seconds = obj.data[item].duration - minutes * 60;
 
-//                                if (typeof obj.data[item].artist === 'undefined') {
-//                                    var details = "<td colspan=\"2\">" + obj.data[item].title + "</td>";
-//                                } else {
-//                                    var details = "<td>" + obj.data[item].artist + "<span>" + obj.data[item].album + "</span></td><td>" + obj.data[item].title + "</td>";
-//                                }
+                                if (obj.data[item].artist == null) {
+                                    var artist = "<td colspan=\"2\">";
+                                } else {
+                                    var artist = "<td>" + obj.data[item].artist +
+                                                     "<span>" + obj.data[item].album + "</span></td><td>";
+                                }
 
                                 $('#salamisandwich > tbody').append(
                                     "<tr uri=\"" + encodeURI(obj.data[item].uri) + "\" class=\"song\">" +
                                     "<td><span class=\"glyphicon glyphicon-music\"></span></td>" +
-                                    "<td>" + obj.data[song].artist + "<span>" + obj.data[song].album + "</span></td>" +
-                                    "<td>" + obj.data[song].title + "</td>" +
+                                    artist + obj.data[item].title + "</td>" +
                                     "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
                                     "</td><td></td></tr>"
                                 );

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -45,6 +45,8 @@ var app = $.sammy(function() {
         socket.send('MPD_API_GET_QUEUE,'+pagination);
 
         $('#panel-heading').text("Queue");
+        $('#panel-heading-info').empty();
+
         $('#queue').addClass('active');
     }
 
@@ -121,6 +123,8 @@ var app = $.sammy(function() {
         $('#dirble_right').find("tr:gt(0)").remove();
 
         $('#panel-heading').text("Dirble");
+        $('#panel-heading-info').empty();
+
         $('#dirble').addClass('active');
 
         $('#next').addClass('hide');
@@ -147,6 +151,8 @@ var app = $.sammy(function() {
         $('#dirble_right').find("tr:gt(0)").remove();
 
         $('#panel-heading').text("Dirble");
+        $('#panel-heading-info').empty();
+
         $('#dirble').addClass('active');
 
         dirble_stations = false;

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -8,7 +8,7 @@
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along
@@ -385,16 +385,16 @@ function webSocketConnect() {
                                 var seconds = obj.data[item].duration - minutes * 60;
 
                                 if (obj.data[item].artist == null) {
-                                    var artist = "<td colspan=\"2\">";
+                                    var artist = " colspan=\"2\">";
                                 } else {
-                                    var artist = "<td>" + obj.data[item].artist +
+                                    var artist = ">" + obj.data[item].artist +
                                                      "<span>" + obj.data[item].album + "</span></td><td>";
                                 }
 
                                 $('#salamisandwich > tbody').append(
                                     "<tr uri=\"" + encodeURI(obj.data[item].uri) + "\" class=\"song\">" +
                                     "<td><span class=\"glyphicon glyphicon-music\"></span></td>" +
-                                    artist + obj.data[item].title + "</td>" +
+                                    "<td" + artist + obj.data[item].title + "</td>" +
                                     "<td>" + minutes + ":" + (seconds < 10 ? '0' : '') + seconds +
                                     "</td><td></td></tr>"
                                 );
@@ -537,15 +537,13 @@ function webSocketConnect() {
                 case 'outputnames':
                     $('#btn-outputs-block button').remove();
                     if (obj.data.length > 1) {
-                        $.each(obj.data, function(id, name){
-                            var btn = $('<button id="btnoutput' + id +
-                                            '" class="btn btn-default" onclick="toggleoutput(this, ' + id + ')">' +
-                                        '<span class="glyphicon glyphicon-volume-up"></span> ' + name + '</button>');
+		        $.each(obj.data, function(id, name){
+                            var btn = $('<button id="btnoutput'+id+'" class="btn btn-default" onclick="toggleoutput(this, '+id+')"><span class="glyphicon glyphicon-volume-up"></span> '+name+'</button>');
                             btn.appendTo($('#btn-outputs-block'));
                         });
-                    } else {
+		    } else {
                         $('#btn-outputs-block').addClass('hide');
-                    }
+		    }
                     /* remove cache, since the buttons have been recreated */
                     last_outputs = '';
                     break;

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -194,9 +194,16 @@ $(document).ready(function(){
 
     $('#addstream').on('shown.bs.modal', function () {
         $('#streamurl').focus();
-     })
-    $('#addstream form').on('submit', function (e) {
+    })
+    $('#addstream form').on('submit', function () {
         addStream();
+    });
+
+    $('#savequeue').on('shown.bs.modal', function () {
+        $('#queuename').focus();
+    });
+    $('#savequeue form').on('submit', function () {
+        saveQueue();
     });
 
     if(!notificationsSupported())
@@ -865,16 +872,17 @@ $('.page-btn').on('click', function (e) {
 
 function addStream() {
     if($('#streamurl').val().length > 0) {
-        socket.send('MPD_API_ADD_TRACK,'+$('#streamurl').val());
+        socket.send('MPD_API_ADD_TRACK,' + $('#streamurl').val());
     }
     $('#streamurl').val("");
     $('#addstream').modal('hide');
 }
 
 function saveQueue() {
-    if($('#playlistname').val().length > 0) {
-        socket.send('MPD_API_SAVE_QUEUE,'+$('#playlistname').val());
+    if($('#queuename').val().length > 0) {
+        socket.send('MPD_API_SAVE_QUEUE,' + $('#queuename').val());
     }
+    $('#queuename').val("");
     $('#savequeue').modal('hide');
 }
 

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -42,7 +42,7 @@ var app = $.sammy(function() {
         $('#filter').addClass('hide');
         $('#salamisandwich').removeClass('hide').find("tr:gt(0)").remove();
         $('#dirble_panel').addClass('hide');
-        socket.send('MPD_API_GET_QUEUE,'+pagination);
+        socket.send('MPD_API_GET_QUEUE,' + pagination);
 
         $('#panel-heading').text("Queue");
         $('#queue').addClass('active');
@@ -67,17 +67,18 @@ var app = $.sammy(function() {
         browsepath = this.params['splat'][1];
         pagination = parseInt(this.params['splat'][0]);
         current_app = 'browse';
-        $('#breadcrump').removeClass('hide').empty().append("<li><a href=\"#/browse/0/\" onclick=\"set_filter()\">root</a></li>");
+        $('#breadcrump').removeClass('hide').empty().append(
+            "<li><a href=\"#/browse/0/\" onclick=\"set_filter()\">root</a></li>");
         $('#filter').removeClass('hide');
         $('#salamisandwich').removeClass('hide').find("tr:gt(0)").remove();
         $('#dirble_panel').addClass('hide');
-        socket.send('MPD_API_GET_BROWSE,'+pagination+','+(browsepath ? browsepath : "/"));
+        socket.send('MPD_API_GET_BROWSE,' + pagination + ',' + (browsepath ? browsepath : "/"));
         // Don't add all songs from root
         if (browsepath) {
             var add_all_songs = $('#add-all-songs');
             add_all_songs.off(); // remove previous binds
             add_all_songs.on('click', function() {
-                socket.send('MPD_API_ADD_TRACK,'+browsepath);
+                socket.send('MPD_API_ADD_TRACK,' + browsepath);
             });
             add_all_songs.show();
         }
@@ -87,12 +88,12 @@ var app = $.sammy(function() {
         var full_path = "";
         $.each(path_array, function(index, chunk) {
             if(path_array.length - 1 == index) {
-                $('#breadcrump').append("<li class=\"active\">"+ chunk + "</li>");
+                $('#breadcrump').append("<li class=\"active\">" + chunk + "</li>");
                 return;
             }
 
             full_path = full_path + chunk;
-            $('#breadcrump').append("<li><a href=\"#/browse/0/" + full_path + "\">"+chunk+"</a></li>");
+            $('#breadcrump').append("<li><a href=\"#/browse/0/" + full_path + "\">" + chunk + "</a></li>");
             full_path += "/";
         });
         $('#browse').addClass('active');
@@ -102,18 +103,20 @@ var app = $.sammy(function() {
         current_app = 'search';
         $('#salamisandwich').find("tr:gt(0)").remove();
         $('#dirble_panel').addClass('hide');
-        var searchstr = this.params['splat'][0];
+        var search_str = this.params['splat'][0];
 
-        $('#search > div > input').val(searchstr);
-        socket.send('MPD_API_SEARCH,' + searchstr);
-
-        $('#panel-heading').text("Search: "+searchstr);
+        $('#search > div > input').val(search_str);
+        if (search_str !== "") {
+            socket.send('MPD_API_SEARCH,' + search_str);
+            $('#panel-heading').text("Search: " + search_str);
+        }
     });
 
     this.get(/\#\/dirble\/(\d+)\/(\d+)/, function() {
         prepare();
         current_app = 'dirble';
-        $('#breadcrump').removeClass('hide').empty().append("<li><a href=\"#/dirble/\">Categories</a></li><li>"+dirble_selected_cat+"</li>");
+        $('#breadcrump').removeClass('hide').empty().append(
+            "<li><a href=\"#/dirble/\">Categories</a></li><li>" + dirble_selected_cat + "</li>");
         $('#salamisandwich').addClass('hide');
         $('#dirble_panel').removeClass('hide');
         $('#dirble_loading').removeClass('hide');
@@ -391,9 +394,11 @@ function webSocketConnect() {
                             }).fadeTo('fast',1);
                     }
 
-                    if ( isTouch ) {
-                        appendClickableIcon($("#salamisandwich > tbody > tr.dir > td:last-child"), 'MPD_API_ADD_TRACK', 'plus');
-                        appendClickableIcon($("#salamisandwich > tbody > tr.song > td:last-child"), 'MPD_API_ADD_TRACK', 'play');
+                    if (isTouch) {
+                        appendClickableIcon(
+                            $("#salamisandwich > tbody > tr.dir > td:last-child"), 'MPD_API_ADD_TRACK', 'plus');
+                        appendClickableIcon(
+                            $("#salamisandwich > tbody > tr.song > td:last-child"), 'MPD_API_ADD_TRACK', 'play');
                     } else {
                         $('#salamisandwich > tbody > tr').on({
                             mouseenter: function() {
@@ -462,7 +467,8 @@ function webSocketConnect() {
                         total_minutes + ":" + (total_seconds < 10 ? '0' : '') + total_seconds);
 
                     $('#salamisandwich > tbody > tr').removeClass('active').css("font-weight", "");
-                    $('#salamisandwich > tbody > tr[trackid='+obj.data.currentsongid+']').addClass('active').css("font-weight", "bold");
+                    $('#salamisandwich > tbody > tr[trackid=' +
+                        obj.data.currentsongid + ']').addClass('active').css("font-weight", "bold");
 
                     if(obj.data.random)
                         $('#btnrandom').addClass("active")
@@ -494,13 +500,15 @@ function webSocketConnect() {
                 case 'outputnames':
                     $('#btn-outputs-block button').remove();
                     if (obj.data.length > 1) {
-		        $.each(obj.data, function(id, name){
-                            var btn = $('<button id="btnoutput'+id+'" class="btn btn-default" onclick="toggleoutput(this, '+id+')"><span class="glyphicon glyphicon-volume-up"></span> '+name+'</button>');
+                        $.each(obj.data, function(id, name){
+                            var btn = $('<button id="btnoutput' + id +
+                                            '" class="btn btn-default" onclick="toggleoutput(this, ' + id + ')">' +
+                                        '<span class="glyphicon glyphicon-volume-up"></span> ' + name + '</button>');
                             btn.appendTo($('#btn-outputs-block'));
                         });
-		    } else {
+                    } else {
                         $('#btn-outputs-block').addClass('hide');
-		    }
+                    }
                     /* remove cache, since the buttons have been recreated */
                     last_outputs = '';
                     break;
@@ -525,7 +533,7 @@ function webSocketConnect() {
                     break;
                 case 'update_queue':
                     if(current_app === 'queue')
-                        socket.send('MPD_API_GET_QUEUE,'+pagination);
+                        socket.send('MPD_API_GET_QUEUE,' + pagination);
                     break;
                 case 'song_change':
 
@@ -776,11 +784,15 @@ function getHost() {
 }
 
 $('#search').submit(function () {
-    app.setLocation("#/search/"+$('#search > div > input').val());
-    $('#wait').modal('show');
-    setTimeout(function() {
-        $('#wait').modal('hide');
-    }, 10000);
+    var search_str = $('#search > div > input').val();
+    app.setLocation("#/search/" + search_str);
+
+    if (search_str !== "") {
+        $('#wait').modal('show');
+        setTimeout(function() {
+            $('#wait').modal('hide');
+        }, 10000);
+    }
     return false;
 });
 
@@ -907,7 +919,7 @@ function dirble_load_categories() {
 
     dirble_page = 1;
 
-    $.getJSON( "https://api.dirble.com/v2/categories?token=" + dirble_api_token, function( data ) {
+    $.getJSON("https://api.dirble.com/v2/categories?token=" + dirble_api_token, function( data ) {
 
         $('#dirble_loading').addClass('hide');
 
@@ -917,20 +929,20 @@ function dirble_load_categories() {
 
         var max = data.length - data.length%2;
 
-        for(i = 0; i < max; i+=2) {
+        for(i = 0; i < max; i += 2) {
 
             $('#dirble_left > tbody').append(
-                "<tr><td catid=\""+data[i].id+"\">"+data[i].title+"</td></tr>"
+                "<tr><td catid=\"" + data[i].id + "\">" + data[i].title + "</td></tr>"
             );
 
             $('#dirble_right > tbody').append(
-                "<tr><td catid=\""+data[i+1].id+"\">"+data[i+1].title+"</td></tr>"
+                "<tr><td catid=\"" + data[i+1].id + "\">" + data[i+1].title + "</td></tr>"
             );
         }
 
         if (max != data.length) {
             $('#dirble_left > tbody').append(
-                "<tr><td catid=\""+data[max].id+"\">"+data[max].title+"</td></tr>"
+                "<tr><td catid=\"" + data[max].id + "\">" + data[max].title + "</td></tr>"
             );
         }
 
@@ -938,7 +950,7 @@ function dirble_load_categories() {
             click: function() {
                 dirble_selected_cat = $(this).text();
                 dirble_catid = $(this).attr("catid");
-                app.setLocation("#/dirble/"+dirble_catid+"/"+dirble_page);
+                app.setLocation("#/dirble/" + dirble_catid + "/" + dirble_page);
             }
         });
 
@@ -946,7 +958,7 @@ function dirble_load_categories() {
             click: function() {
                 dirble_selected_cat = $(this).text();
                 dirble_catid = $(this).attr("catid");
-                app.setLocation("#/dirble/"+dirble_catid+"/"+dirble_page);
+                app.setLocation("#/dirble/" + dirble_catid + "/" + dirble_page);
             }
         });
     });
@@ -955,7 +967,8 @@ function dirble_load_categories() {
 
 function dirble_load_stations() {
 
-    $.getJSON( "https://api.dirble.com/v2/category/"+dirble_catid+"/stations?page="+dirble_page+"&per_page=20&token=" + dirble_api_token, function( data ) {
+    $.getJSON("https://api.dirble.com/v2/category/" + dirble_catid +
+        "/stations?page=" + dirble_page + "&per_page=20&token=" + dirble_api_token, function( data ) {
 
         $('#dirble_loading').addClass('hide');
         if (data.length == 20) $('#next').removeClass('hide');
@@ -965,16 +978,16 @@ function dirble_load_stations() {
         for(i = 0; i < max; i+=2) {
 
             $('#dirble_left > tbody').append(
-                "<tr><td radioid=\""+data[i].id+"\">"+data[i].name+"</td></tr>"
+                "<tr><td radioid=\"" + data[i].id + "\">" + data[i].name + "</td></tr>"
             );
             $('#dirble_right > tbody').append(
-                "<tr><td radioid=\""+data[i+1].id+"\">"+data[i+1].name+"</td></tr>"
+                "<tr><td radioid=\"" + data[i+1].id + "\">" + data[i+1].name + "</td></tr>"
             );
         }
 
         if (max != data.length) {
             $('#dirble_left > tbody').append(
-                "<tr><td radioid=\""+data[max].id+"\">"+data[max].name+"</td></tr>"
+                "<tr><td radioid=\"" + data[max].id + "\">" + data[max].name + "</td></tr>"
             );
         }
 
@@ -982,7 +995,8 @@ function dirble_load_stations() {
             click: function() {
                 var _this = $(this);
 
-                $.getJSON( "https://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token=" + dirble_api_token, function( data ) {
+                $.getJSON("https://api.dirble.com/v2/station/" +
+                    $(this).attr("radioid") + "?token=" + dirble_api_token, function( data ) {
 
                     socket.send("MPD_API_ADD_TRACK," + data.streams[0].stream);
                     $('.top-right').notify({
@@ -1000,7 +1014,8 @@ function dirble_load_stations() {
                 "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
                     e.stopPropagation();
 
-                    $.getJSON( "https://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token=" + dirble_api_token, function( data ) {
+                    $.getJSON("https://api.dirble.com/v2/station/" +
+                        _this.attr("radioid") + "?token=" + dirble_api_token, function( data ) {
 
                         socket.send("MPD_API_ADD_PLAY_TRACK," + data.streams[0].stream);
                         $('.top-right').notify({
@@ -1021,7 +1036,8 @@ function dirble_load_stations() {
             click: function() {
                 var _this = $(this);
 
-                $.getJSON( "https://api.dirble.com/v2/station/"+$(this).attr("radioid")+"?token=" + dirble_api_token, function( data ) {
+                $.getJSON("https://api.dirble.com/v2/station/" +
+                    $(this).attr("radioid") + "?token=" + dirble_api_token, function( data ) {
 
                     socket.send("MPD_API_ADD_TRACK," + data.streams[0].stream);
                     $('.top-right').notify({
@@ -1036,10 +1052,11 @@ function dirble_load_stations() {
 
                 $(this).last().append(
                 "<a role=\"button\" class=\"pull-right btn-group-hover\">" +
-                "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
+                    "<span class=\"glyphicon glyphicon-play\"></span></a>").find('a').click(function(e) {
                     e.stopPropagation();
 
-                    $.getJSON( "https://api.dirble.com/v2/station/"+_this.attr("radioid")+"?token=" + dirble_api_token, function( data ) {
+                    $.getJSON("https://api.dirble.com/v2/station/" +
+                        _this.attr("radioid") + "?token=" + dirble_api_token, function( data ) {
 
                         socket.send("MPD_API_ADD_PLAY_TRACK," + data.streams[0].stream);
                         $('.top-right').notify({
@@ -1108,5 +1125,6 @@ function add_filter () {
         $('#filter').append('&nbsp;<a onclick="set_filter(\'' + c + '\')" href="#/browse/0/">' + c + '</a>');
     }
 
-    $('#filter').append('&nbsp;<a onclick="set_filter(\'||\')" href="#/browse/0/" class="glyphicon glyphicon-list"></a>');
+    $('#filter').append(
+        '&nbsp;<a onclick="set_filter(\'||\')" href="#/browse/0/" class="glyphicon glyphicon-list"></a>');
 }

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -101,6 +101,7 @@ var app = $.sammy(function() {
             full_path += "/";
         });
         $('#browse').addClass('active');
+        $('#browse > a').attr('href', '#/browse/' + pagination + '/' + browsepath);
     });
 
     this.get(/\#\/search\/(.*)/, function() {
@@ -452,8 +453,8 @@ function webSocketConnect() {
                                 case 'dir':
                                     pagination = 0;
                                     browsepath = $(this).attr("uri");
-                                    $("#browse > a").attr("href", '#/browse/'+pagination+'/'+browsepath);
-                                    app.setLocation('#/browse/'+pagination+'/'+browsepath);
+                                    $("#browse > a").attr("href", '#/browse/' + pagination + '/' + browsepath);
+                                    app.setLocation('#/browse/' + pagination + '/' + browsepath);
                                     break;
                                 case 'song':
                                     socket.send("MPD_API_ADD_TRACK," + decodeURI($(this).attr("uri")));

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -112,6 +112,8 @@ var app = $.sammy(function() {
 
             socket.send('MPD_API_SEARCH,' + search_str);
             $('#panel-heading').text("Search: " + search_str);
+        } else if (current_app == null) {
+            app.setLocation('/');
         }
     });
 

--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -82,7 +82,8 @@ var app = $.sammy(function() {
             add_all_songs.show();
         }
 
-        $('#panel-heading').text("Browse Database: "+browsepath);
+        $('#panel-heading').text("Browse Database" + (browsepath ? ': ' : '') + browsepath);
+
         var path_array = browsepath.split('/');
         var full_path = "";
         $.each(path_array, function(index, chunk) {
@@ -309,7 +310,12 @@ function webSocketConnect() {
                     if ($('#salamisandwich > tbody').is(':ui-sortable')) {
                         $('#salamisandwich > tbody').sortable('destroy');
                     }
-                    for (var item in obj.data) {
+
+                    var obj_data = obj.data.map((x,i) => [x.srt,i]).sort();
+
+                    for (var i = 0; i < obj_data.length; i++) {
+                        var item = obj_data[i][1];
+
                         switch(obj.data[item].type) {
                             case 'directory':
                                 var clazz = 'dir';
@@ -494,8 +500,10 @@ function webSocketConnect() {
                 case 'outputnames':
                     $('#btn-outputs-block button').remove();
                     if (obj.data.length > 1) {
-                            $.each(obj.data, function(id, name){
-                            var btn = $('<button id="btnoutput'+id+'" class="btn btn-default" onclick="toggleoutput(this, '+id+')"><span class="glyphicon glyphicon-volume-up"></span> '+name+'</button>');
+                        $.each(obj.data, function(id, name){
+                            var btn = $('<button id="btnoutput' + id +
+                                            '" class="btn btn-default" onclick="toggleoutput(this, ' + id + ')">' +
+                                        '<span class="glyphicon glyphicon-volume-up"></span> ' + name + '</button>');
                             btn.appendTo($('#btn-outputs-block'));
                         });
                     } else {

--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -8,7 +8,7 @@
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along

--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -1,14 +1,14 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along
@@ -36,11 +36,11 @@ const char * mpd_cmd_strs[] = {
 };
 
 char * get_arg1 (char *p) {
-	return strchr(p, ',') + 1;
+    return strchr(p, ',') + 1;
 }
 
 char * get_arg2 (char *p) {
-	return get_arg1(get_arg1(p));
+    return get_arg1(get_arg1(p));
 }
 
 static inline enum mpd_cmd_ids get_cmd_id(char *cmd)
@@ -59,9 +59,6 @@ int callback_mpd(struct mg_connection *c)
     unsigned int uint_buf, uint_buf_2;
     int int_buf;
     char *p_charbuf = NULL, *token;
-
-    if(cmd_id == -1)
-        return MG_TRUE;
 
     if(mpd.conn_state != MPD_CONNECTED && cmd_id != MPD_API_SET_MPDHOST &&
         cmd_id != MPD_API_GET_MPDHOST && cmd_id != MPD_API_SET_MPDPASS &&
@@ -165,11 +162,11 @@ int callback_mpd(struct mg_connection *c)
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_browse;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             n = mpd_put_browse(mpd.buf, get_arg2(p_charbuf), uint_buf);
 out_browse:
-			free(p_charbuf);
+            free(p_charbuf);
             break;
         case MPD_API_ADD_TRACK:
             p_charbuf = strdup(c->content);
@@ -179,7 +176,7 @@ out_browse:
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_add_track;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             mpd_run_add(mpd.conn, get_arg1(p_charbuf));
 out_add_track:
@@ -193,7 +190,7 @@ out_add_track:
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_play_track;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             int_buf = mpd_run_add_id(mpd.conn, get_arg1(p_charbuf));
             if(int_buf != -1)
@@ -209,7 +206,7 @@ out_play_track:
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_playlist;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             mpd_run_load(mpd.conn, get_arg1(p_charbuf));
 out_playlist:
@@ -223,7 +220,7 @@ out_playlist:
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_save_queue;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             mpd_run_save(mpd.conn, get_arg1(p_charbuf));
 out_save_queue:
@@ -232,12 +229,12 @@ out_save_queue:
         case MPD_API_SEARCH:
             p_charbuf = strdup(c->content);
             if(strcmp(strtok(p_charbuf, ","), "MPD_API_SEARCH"))
-				goto out_search;
+                goto out_search;
 
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_search;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(c->content);
             n = mpd_search(mpd.buf, get_arg1(p_charbuf));
 out_search:
@@ -246,12 +243,12 @@ out_search:
         case MPD_API_SEND_MESSAGE:
             p_charbuf = strdup(c->content);
             if(strcmp(strtok(p_charbuf, ","), "MPD_API_SEND_MESSAGE"))
-				goto out_send_message;
+                goto out_send_message;
 
             if((token = strtok(NULL, ",")) == NULL)
                 goto out_send_message;
 
-			free(p_charbuf);
+            free(p_charbuf);
             p_charbuf = strdup(get_arg1(c->content));
 
             if ( strtok(p_charbuf, ",") == NULL )
@@ -260,7 +257,7 @@ out_search:
             if ( (token = strtok(NULL, ",")) == NULL )
                 goto out_send_message;
 
-			mpd_run_send_message(mpd.conn, p_charbuf, token);
+            mpd_run_send_message(mpd.conn, p_charbuf, token);
 out_send_message:
             free(p_charbuf);
             break;
@@ -481,9 +478,9 @@ char* mpd_get_artist(struct mpd_song const *song)
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_ARTIST, 0);
     if (str == NULL) {
-	return "";
+        return "";
     } else {
-	return str;
+        return str;
     }
 }
 
@@ -493,9 +490,9 @@ char* mpd_get_album(struct mpd_song const *song)
 
     str = (char *)mpd_song_get_tag(song, MPD_TAG_ALBUM, 0);
     if (str == NULL) {
-	return "";
+        return "";
     } else {
-	return str;
+        return str;
     }
 }
 

--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -600,6 +600,7 @@ int mpd_put_queue(char *buffer, unsigned int offset)
     char *cur = buffer;
     const char *end = buffer + MAX_SIZE;
     struct mpd_entity *entity;
+    unsigned long totalTime = 0;
 
     if (!mpd_send_list_queue_range_meta(mpd.conn, offset, offset+MAX_ELEMENTS_PER_PAGE))
         RETURN_ERROR_AND_RECOVER("mpd_send_list_queue_meta");
@@ -608,16 +609,18 @@ int mpd_put_queue(char *buffer, unsigned int offset)
 
     while((entity = mpd_recv_entity(mpd.conn)) != NULL) {
         const struct mpd_song *song;
+        unsigned int drtn;
 
         if(mpd_entity_get_type(entity) == MPD_ENTITY_TYPE_SONG) {
             song = mpd_entity_get_song(entity);
+            drtn = mpd_song_get_duration(song);
 
             cur += json_emit_raw_str(cur, end - cur, "{\"id\":");
             cur += json_emit_int(cur, end - cur, mpd_song_get_id(song));
             cur += json_emit_raw_str(cur, end - cur, ",\"pos\":");
             cur += json_emit_int(cur, end - cur, mpd_song_get_pos(song));
             cur += json_emit_raw_str(cur, end - cur, ",\"duration\":");
-            cur += json_emit_int(cur, end - cur, mpd_song_get_duration(song));
+            cur += json_emit_int(cur, end - cur, drtn);
             cur += json_emit_raw_str(cur, end - cur, ",\"title\":");
             cur += json_emit_quoted_str(cur, end - cur, mpd_get_title(song));
             cur += json_emit_raw_str(cur, end - cur, ",\"artist\":");
@@ -625,6 +628,8 @@ int mpd_put_queue(char *buffer, unsigned int offset)
             cur += json_emit_raw_str(cur, end - cur, ",\"album\":");
             cur += json_emit_quoted_str(cur, end - cur, mpd_get_album(song));
             cur += json_emit_raw_str(cur, end - cur, "},");
+
+            totalTime += drtn;
         }
         mpd_entity_free(entity);
     }
@@ -632,7 +637,9 @@ int mpd_put_queue(char *buffer, unsigned int offset)
     /* remove last ',' */
     cur--;
 
-    cur += json_emit_raw_str(cur, end - cur, "]}");
+    cur += json_emit_raw_str(cur, end - cur, "],\"totalTime\":");
+    cur += json_emit_int(cur, end - cur, totalTime);
+    cur += json_emit_raw_str(cur, end - cur, "}");
     return cur - buffer;
 }
 

--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -758,7 +758,6 @@ int mpd_search(char *buffer, char *searchstr)
     return cur - buffer;
 }
 
-
 void mpd_disconnect()
 {
     mpd.conn_state = MPD_DISCONNECT;

--- a/src/mpd_client.h
+++ b/src/mpd_client.h
@@ -8,7 +8,7 @@
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along

--- a/src/mpd_client.h
+++ b/src/mpd_client.h
@@ -1,21 +1,21 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along
    with this program; if not, write to the Free Software Foundation, Inc.,
    Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-   
+
 #ifndef __MPD_CLIENT_H__
 #define __MPD_CLIENT_H__
 

--- a/src/ympd.c
+++ b/src/ympd.c
@@ -8,7 +8,7 @@
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along

--- a/src/ympd.c
+++ b/src/ympd.c
@@ -1,14 +1,14 @@
 /* ympd
    (c) 2013-2014 Andrew Karpow <andy@ndyk.de>
    This project's homepage is: http://www.ympd.org
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; version 2 of the License.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License along


### PR DESCRIPTION
- Added queue's total time to panel header (closes #47)
- Enable case insensitive sorting of database entries while browsing
- Since an empty search string always seems to just time out, it is now simply ignored

Unfortunately, I had to "pre-merge" the original three branches, since I had to make some final changes for everything to work as expected (and to be auto-mergeable), c.f. 71ec2cd.

Additional changes:
- Removed compiler warning "comparison of constant -1 with expression of type 'enum mpd_cmd_ids' is always false"
- Fixed main table layout in case of an empty queue and search result, respectively
- Split-up of a few very long code lines
- Update link behind navbar's "Browse Database" after every page reload (i.e. after following a link)
- Make text input in "Save Queue" behave like the one in "Add Stream"
- Some clean-up