### PR TITLE
[Issue 128] Current track in page title

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -528,7 +528,7 @@ function webSocketConnect() {
                         socket.send('MPD_API_GET_QUEUE,'+pagination);
                     break;
                 case 'song_change':
-
+                    updatePageTitle(obj.data);
                     $('#album').text("");
                     $('#artist').text("");
 
@@ -552,8 +552,7 @@ function webSocketConnect() {
                         $('.top-right').notify({
                             message:{html: notification},
                             type: "info",
-                        }).show();
-                        
+                        }).show();        
                     break;
                 case 'mpdhost':
                     $('#mpdhost').val(obj.data.host);
@@ -664,6 +663,20 @@ var updatePlayIcon = function(state)
     } else { // play
         $("#play-icon").addClass("glyphicon-play");
         $('#track-icon').addClass("glyphicon-pause");
+    }
+}
+
+var updatePageTitle = function(songInfo) {
+    if(!songInfo || (!songInfo.artist && !songInfo.title)) {
+        document.title = 'ympd';
+        return;
+    }
+    if(songInfo.artist) {
+        if(songInfo.title) {
+            document.title = songInfo.artist + ' - ' + songInfo.title;
+        }
+    } else {
+        document.title = songInfo.title;
     }
 }
 


### PR DESCRIPTION
Now current playing track can be displayed in the page title.
Fix for [Issue 128](https://github.com/notandy/ympd/issues/128)
>Would updating the title with the name of the current music playing be something you guys would like to have in ympd? I think it would look good.