### PR TITLE
bump required cmake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 project (ympd C)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")


### PR DESCRIPTION
Otherwise, on Gentoo you will get an error:
`Compatibility with CMake < 3.5 has been removed from CMake`

And on FreeBSD just a warning:
`Compatibility with CMake < 3.10 will be removed from a future version of CMake`

