### PR TITLE
Multiple definitions of mpd and dirble_api_token

### DIFF
--- a/src/mpd_client.c
+++ b/src/mpd_client.c
@@ -28,6 +28,9 @@
 #include "config.h"
 #include "json_encode.h"
 
+struct t_mpd mpd;
+char dirble_api_token[28];
+
 /* forward declaration */
 static int mpd_notify_callback(struct mg_connection *c, enum mg_event ev);
 

--- a/src/mpd_client.h
+++ b/src/mpd_client.h
@@ -96,9 +96,10 @@ struct t_mpd {
 
     int song_id;
     unsigned queue_version;
-} mpd;
+};
 
-char dirble_api_token[28];
+extern struct t_mpd mpd;
+extern char dirble_api_token[28];
 
 struct t_mpd_client_session {
     int song_id;


### PR DESCRIPTION
```
/usr/lib/gcc/x86_64-pc-linux-gnu/15/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/ympd.dir/src/mpd_client.c.o:(.bss+0x0): multiple definition of `mpd'; CMakeFiles/ympd.dir/src/ympd.c.o:(.bss+0x0): first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/15/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/ympd.dir/src/mpd_client.c.o:(.bss+0x190b0): multiple definition of `dirble_api_token'; CMakeFiles/ympd.dir/src/ympd.c.o:(.bss+0x190b0): first defined here
```