### PR TITLE
don't place artist right to counter if album is not set

### DIFF
--- a/htdocs/js/mpd.js
+++ b/htdocs/js/mpd.js
@@ -540,6 +540,8 @@ function webSocketConnect() {
                     if(obj.data.album) {
                         $('#album').text(obj.data.album);
                         notification += obj.data.album + "<br />";
+                    } else {
+                        $('#album').html("&nbsp;");
                     }
                     if(obj.data.artist) {
                         $('#artist').text(obj.data.artist);


### PR DESCRIPTION
If album is not given, span id="artist" within h4 consumes no height and is placed right to the counter.